### PR TITLE
Ref #13: Add base support for API documentation

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,8 @@ const session = require('express-session');
 const Keycloak = require('keycloak-connect');
 const request = require('request');
 const MySQLSessionStore = require('express-mysql-session')(session);
+const ExpressSwagger = require('express-swagger-generator');
+const Package = require('./package.json');
 
 // Config file
 const config = require('./config/server.config.json');
@@ -40,6 +42,8 @@ const categories = require('./routes/categories.controller');
 
 const app = express();
 
+const expressSwagger = ExpressSwagger(app);
+
 // session in production environment
 if (env === 'production') {
   app.use(session({
@@ -53,6 +57,34 @@ if (env === 'production') {
   }));
 }
 
+const swaggerOptions = {
+  swaggerDefinition: {
+    info: {
+      description: Package.description,
+      title: 'Documentation API',
+      version: Package.version,
+    },
+    host: `${config.doc.baseHost}`,
+    basePath: `/api/v${version}`,
+    produces: [
+      'application/json',
+      'application/xml',
+    ],
+    schemes: ['http', 'https'],
+    securityDefinitions: {
+      // JWT: {
+      //   type: 'apiKey',
+      //   in: 'header',
+      //   name: 'Authorization',
+      //   description: '',
+      // },
+    },
+  },
+  basedir: __dirname, // app absolute path
+  files: ['./routes/**/*.js'], // Path to the API handle folder
+};
+
+expressSwagger(swaggerOptions);
 const router = express.Router();
 
 // view engine setup

--- a/config/server.config.json
+++ b/config/server.config.json
@@ -4,5 +4,8 @@
         "port": 4000,
         "version": 1
     },
+    "doc": {
+        "baseHost": "localhost:4000"
+    },
     "secretKey": "placeholderToBeChanged"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "porygon-backend",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1082,6 +1082,12 @@
         }
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1601,6 +1607,26 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "doctrine-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/doctrine-file/-/doctrine-file-1.0.3.tgz",
+      "integrity": "sha512-OK37HbZtNmIMn84riibVXRmcEGUIf6BNfYMcbXg20ejP+LEsf4tnk8QfYy3EmQs4KzZFhTl3zwoKqVwARxpBgA==",
+      "dev": true,
+      "requires": {
+        "doctrine": "^2.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
       }
     },
     "doctypes": {
@@ -2247,6 +2273,40 @@
         }
       }
     },
+    "express-swagger-generator": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/express-swagger-generator/-/express-swagger-generator-1.1.15.tgz",
+      "integrity": "sha512-dOqXj+amehXMyPxGnkHDdGDGSxQy5fBrZ74d3L7noLfGDC2b6pb+uziZ/QcBth/w6AwtxpUWlRI9K0hyoIQRvQ==",
+      "dev": true,
+      "requires": {
+        "doctrine": "^2.0.0",
+        "doctrine-file": "^1.0.2",
+        "express-swaggerize-ui": "^1.0.3",
+        "glob": "^7.0.3",
+        "recursive-iterator": "^2.0.3",
+        "swagger-parser": "^5.0.5"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
+    "express-swaggerize-ui": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/express-swaggerize-ui/-/express-swaggerize-ui-1.1.0.tgz",
+      "integrity": "sha512-dDJuWV/GlISNYyKvFMa3EDr6sYzMgMrVRCt9o1kQxaIIKnmK1NJvaTzGbRIokIlGGHriIT6E2ztorRyRxLuOzA==",
+      "dev": true,
+      "requires": {
+        "express": "^4.13.3"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2589,6 +2649,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=",
+      "dev": true
     },
     "formidable": {
       "version": "1.2.1",
@@ -4568,6 +4634,35 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-ref-parser": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-5.1.3.tgz",
+      "integrity": "sha512-CpDFlBwz/6la78hZxyB9FECVKGYjIIl3Ms3KLqFj99W7IIb7D00/RDgc++IGB4BBALl0QRhh5m4q5WNSopvLtQ==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.1.0",
+        "js-yaml": "^3.12.0",
+        "ono": "^4.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4600,6 +4695,18 @@
           "dev": true
         }
       }
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
+    "jsonschema-draft4": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
+      "integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -4792,6 +4899,18 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -5358,6 +5477,26 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "ono": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+      "dev": true,
+      "requires": {
+        "format-util": "^1.0.3"
+      }
+    },
+    "openapi-schema-validation": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
+      "integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
+      "dev": true,
+      "requires": {
+        "jsonschema": "1.2.4",
+        "jsonschema-draft4": "^1.0.0",
+        "swagger-schema-official": "2.0.0-bab6bed"
       }
     },
     "optimist": {
@@ -6019,6 +6158,12 @@
       "requires": {
         "resolve": "^1.1.6"
       }
+    },
+    "recursive-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/recursive-iterator/-/recursive-iterator-2.0.3.tgz",
+      "integrity": "sha1-0ODSx+eoMQnXMJHPBD/FCeWnbcM=",
+      "dev": true
     },
     "regenerator-runtime": {
       "version": "0.11.1",
@@ -6845,6 +6990,51 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swagger-methods": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
+      "integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA==",
+      "dev": true
+    },
+    "swagger-parser": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-5.0.6.tgz",
+      "integrity": "sha512-FdzCYFK11iGgrOpojlqUluU6SKThtzmu+5Get+6ValJR2TFwTnES1x4Fdfgy3C4/8VVXk4Va/WsqGlbyY/Os+A==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.1.0",
+        "json-schema-ref-parser": "^5.1.3",
+        "ono": "^4.0.6",
+        "openapi-schema-validation": "^0.4.2",
+        "swagger-methods": "^1.0.4",
+        "swagger-schema-official": "2.0.0-bab6bed",
+        "z-schema": "^3.23.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "swagger-schema-official": {
+      "version": "2.0.0-bab6bed",
+      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
+      "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0=",
+      "dev": true
+    },
     "symbol-observable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -7249,6 +7439,12 @@
         "spdx-expression-parse": "~1.0.0"
       }
     },
+    "validator": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
+      "dev": true
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -7463,6 +7659,19 @@
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         }
+      }
+    },
+    "z-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
+      "integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.7.1",
+        "core-js": "^2.5.7",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^10.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express": "^4.17.1",
     "express-mysql-session": "^2.1.0",
     "express-session": "^1.16.2",
+    "express-swagger-generator": "^1.1.15",
     "keycloak-connect": "^6.0.1",
     "knex": "^0.19.5",
     "morgan": "^1.9.1",

--- a/routes/categories.controller.js
+++ b/routes/categories.controller.js
@@ -4,7 +4,13 @@ const router = express.Router();
 
 const CategoriesService = require('../services/categories.service');
 
-
+/**
+ * This function comment is parsed by doctrine
+ * @route GET /categories
+ * @group foo - Operations about categories
+ * @returns {object} 200 - An array of categories in database
+ * @returns {Error}  default - Unexpected error
+ */
 const getAllCategories = (req, res, next) => {
   const onNext = (data) => {
     res.json(data);


### PR DESCRIPTION
Add basic support for future documentation using Swagger. Documentation
has not yet been written, but the requirements to write and display it
in the future are present.