### PR TITLE
Ref #25: Add support for unix socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ RUN rm /usr/src/app/config/server.config.json
 RUN ln -s /config/server.config.json /usr/src/app/config/server.config.json
 
 RUN mkdir /logs
+RUN mkdir /socket
 
 VOLUME /config
 VOLUME /logs
+VOLUME /socket
 
 RUN npm install
 EXPOSE 4000

--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ server.config.json
 
 {
     "server": {
+        "listenTarget": "socket",
         "host": "127.0.0.1",
         "port": 4000,
+        "socket": "/tmp/porygon.sock",
         "version": 1,
         "frontendOrigin": "http://127.0.0.1:8080",
         "logLevel": "info",
@@ -110,8 +112,10 @@ server.config.json
 
 | Value | Role |
 | ---: | :--- |
-| `server.host` | Host the server will listen to. Set it to `0.0.0.0` if you want your server to listen to all routes, or `127.0.0.1` if you are behind a reverse proxy |
-| `server.port` | The port the server will listen to |
+| `server.listenTarget` | Select whether server should listen on a socket or a port, can be `port` or `socket` |
+| `server.host` | Host the server will listen to. Set it to `0.0.0.0` if you want your server to listen to all routes, or `127.0.0.1` if you are behind a reverse proxy (**Necessary when `listenTarget` is set to `port`**) |
+| `server.port` | The port the server will listen to (**Necessary when `listenTarget` is set to `port`**) |
+| `server.socket` | The path of the socket into which the server will write, the user must have permission to access this file (**Necessary when `listenTarget` is set to `socket`**)
 | `server.version` | Value automatically appended to all API routes, e.g. `http://localhost:4000/api/v1/movies` |
 | `server.frontendOrigin` | Used by the `Access-Control` to limit the origin of requests. It should be set to the frontend host, e.g. `https://porygon.example.com` |
 | `server.logLevel` | Log level for the server logger, can be set to `"debug"`, `"info"`, `"warning"`, `"error"` |
@@ -152,6 +156,8 @@ set the database and optionnal keycloak config files and a `/logs` volume to sto
 
 For this reason, the `server.logDirectory` should be set to `/logs` in order for the logs to be visible 
 outside the container
+
+A third volume `/socket` is also available if the container should expose a socket instead of a port. In this case, the `server.socket` should be set to `/socket/<yoursocket>.sock`.
 
 If necessary to access the database, the host networking can be used with the flag `--network="host"`.
 

--- a/bin/www
+++ b/bin/www
@@ -6,11 +6,14 @@
 
 const http = require('http');
 const log4js = require('log4js');
+const fs = require('fs');
 const app = require('../app');
 const config = require('../config/server.config.json');
 
 const env = process.env.NODE_ENV || 'development';
 const logger = log4js.getLogger(env === 'development' ? 'dev' : 'prod');
+
+const listenTarget = config.server.listenTarget || 'port';
 
 /**
  * Normalize a port into a number, string, or false.
@@ -38,7 +41,7 @@ function normalizePort(val) {
 
 const port = normalizePort(config.server.port || '3000');
 const host = config.server.host || '0.0.0.0';
-app.set('port', port);
+const socketPath = config.server.socket || '/tmp/porygon.sock';
 
 /**
  * Create HTTP server.
@@ -51,27 +54,28 @@ const server = http.createServer(app);
  */
 
 function onError(error) {
-  if (error.syscall !== 'listen') {
-    throw error;
-  }
+  logger.fatal(error);
+  // if (error.syscall !== 'listen') {
+  //   throw error;
+  // }
 
-  const bind = typeof port === 'string'
-    ? `Pipe ${port}`
-    : `Port ${port}`;
+  // const bind = typeof port === 'string'
+  //   ? `Pipe ${port}`
+  //   : `Port ${port}`;
 
-  // handle specific listen errors with friendly messages
-  switch (error.code) {
-    case 'EACCES':
-      logger.fatal(`${bind} requires elevated privileges`);
-      process.exit(1);
-      break;
-    case 'EADDRINUSE':
-      logger.fatal(`${bind} is already in use`);
-      process.exit(1);
-      break;
-    default:
-      throw error;
-  }
+  // // handle specific listen errors with friendly messages
+  // switch (error.code) {
+  //   case 'EACCES':
+  //     logger.fatal(`${bind} requires elevated privileges`);
+  //     process.exit(1);
+  //     break;
+  //   case 'EADDRINUSE':
+  //     logger.fatal(`${bind} is already in use`);
+  //     process.exit(1);
+  //     break;
+  //   default:
+  //     throw error;
+  // }
 }
 
 /**
@@ -79,17 +83,55 @@ function onError(error) {
  */
 
 function onListening() {
-  const addr = server.address();
-  const bind = typeof addr === 'string'
-    ? `pipe ${addr}`
-    : `port ${addr.port}`;
-  logger.info(`Listening on ${bind}`);
+  logger.info('Server currently listening');
+}
+
+
+/**
+ * Cleanup on exit
+ */
+function onExit() {
+  logger.info('Cleaning-up');
+  if (listenTarget === 'socket') {
+    logger.debug(`Removing socket ${socketPath}`);
+
+    try {
+      fs.unlinkSync(socketPath);
+      logger.debug('Socket removed');
+    } catch (error) {
+      switch (error.code) {
+        case 'ENOENT':
+          logger.debug('Socket file does not exist.');
+          break;
+        default:
+          logger.fatal(error);
+          process.exit(1);
+      }
+    }
+  }
+  process.exit(0);
 }
 
 
 /**
    * Listen on provided port, on all network interfaces.
    */
-server.listen(port, host);
+switch (listenTarget) {
+  case 'port':
+    logger.info(`Server listening to host ${host} on port ${port}`);
+    server.listen(port, host);
+    break;
+  case 'socket':
+    logger.info(`Server listening to socket ${socketPath}`);
+    server.listen(socketPath, () => {
+      fs.chmodSync(socketPath, '666');
+    });
+    break;
+  default:
+    logger.fatal(`Unrecognized listening option '${listenTarget}', options are 'port' and 'socket'`);
+    break;
+}
+
 server.on('error', onError);
 server.on('listening', onListening);
+process.on('SIGINT', onExit);

--- a/config/server.config.json
+++ b/config/server.config.json
@@ -1,5 +1,7 @@
 {
     "server": {
+        "listenTarget": "socket",
+        "socket": "/tmp/porygon.sock",
         "host": "0.0.0.0",
         "port": 4000,
         "version": 1,


### PR DESCRIPTION
Allow connecting the API to a UNIX socket instead of a port, and update
documentation and Docker image to match these changes.